### PR TITLE
Loosen dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "watch:test": "jest --watch"
   },
   "dependencies": {
-    "@streammedev/perfnow": "^2.1.0",
-    "lodash": "^4.17.4",
-    "moment-timezone": "^0.5.13",
-    "protobind": "^1.0.7",
-    "uuid": "^3.1.0"
+    "@streammedev/perfnow": "^2.0.0",
+    "lodash": "^4.0.0",
+    "moment-timezone": "^0.5.0",
+    "protobind": "^1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^20.0.5",


### PR DESCRIPTION
The more we can loosen dependencies, the fewer copies of each library consumers have to put up with