### PR TITLE
Default span name for decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const apiReporter = new Reporter({
 });
 ```
 
-The reporter will call `flushHandler` if there are any traces to report on the next [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) (browser) after recording the trace or every `evaluateFlushIntervalSeconds`.
+The reporter will call `flushHandler` if there are any traces to report on the next [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) (browser) after recording the trace or every `flushIntervalSeconds`.
 
 ### Trace Decorator ###
 Decorators are a convenient way to add tracing to an app or service. This library exposes a decorator factory function to generate a decorator that can be reused through your app or service. It establishes a default `service` name to use for all traces, specifies the reporter, the sample rate (recommended for frequently called functions) and the ability to configure which argument in the traced function a context object will be read from or created at (nice when the function you are tracing uses a framework that puts the context object at different positions, such as a GQL resolver or Express middleware).

--- a/__tests__/Reporter.ts
+++ b/__tests__/Reporter.ts
@@ -159,7 +159,7 @@ describe(`Reporter`, () => {
     reporter.reportTiming(timing);
     reporter.reportTrace(trace);
     (reporter as any).lastFlush = null;
-    jest.runTimersToTime((reporter as any).config.evaluateFlushIntervalSeconds * 1000 * 5);
+    jest.runTimersToTime((reporter as any).config.flushIntervalSeconds * 1000 * 5);
 
     expect(reporter.flush).toHaveBeenCalledTimes(1);
   });

--- a/__tests__/traceFunc.ts
+++ b/__tests__/traceFunc.ts
@@ -97,7 +97,7 @@ describe(`createTraceDecorator`, () => {
     const something = new Something();
 
     something.doSomething(1);
-    jest.runTimersToTime((reporter as any).config.evaluateFlushIntervalSeconds * 1000);
+    jest.runTimersToTime((reporter as any).config.flushIntervalSeconds * 1000);
 
     expect(mock).toHaveBeenCalledTimes(1);
     const traces = mock.mock.calls[0][1];

--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -9,7 +9,6 @@ import { AbstractReporter, Logger, ReporterConfiguration, TracerConfiguration, T
 export const defaultReporterConfig:ReporterConfiguration = {
   maxTimingsBatchSize: 50,
   maxTracesBatchSize: 20,
-  evaluateFlushIntervalSeconds: 5,
   flushIntervalSeconds: 30,
   logger: console,
   flushHandler: _.noop,
@@ -47,7 +46,7 @@ export default class Reporter implements AbstractReporter {
       this.isPending = true;
       idleCallback(
         this.flushIfNeeded.bind(this),
-        +moment.duration(this.config.evaluateFlushIntervalSeconds, 'seconds'),
+        +moment.duration(this.config.flushIntervalSeconds, 'seconds'),
       );
     }
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,7 +42,6 @@ export interface ReporterParamsConfiguration {
   maxTimingsBatchSize?: number;
   maxTracesBatchSize?: number;
   flushIntervalSeconds?: number;
-  evaluateFlushIntervalSeconds?: number;
   logger?: Logger;
   flushHandler?: FlushFunction;
 }

--- a/src/traceFunc.ts
+++ b/src/traceFunc.ts
@@ -52,10 +52,12 @@ export function traceFunc({
 
 export function createTraceDecorator({
   service: defaultService,
+  resource: defaultResource,
   tracerConfig,
   contextArgumentPosition = 1,
 }:{
   service:string,
+  resource:string,
   tracerConfig:TracerConfiguration,
   contextArgumentPosition:number,
 }) {
@@ -78,7 +80,7 @@ export function createTraceDecorator({
       const tracedFunction = descriptor.value;
       descriptor.value = function traceDecorator(...args:any[]) {
         return traceFunction.call(this, {
-          resource,
+          resource: resource || defaultResource,
           service: service || defaultService,
           tracerConfig,
           contextArgumentPosition,
@@ -96,10 +98,12 @@ export function createTraceDecorator({
 
 export function createTraceFunction({
   service: defaultService,
+  resource: defaultResource,
   tracerConfig,
   contextArgumentPosition = 1,
 }:{
   service:string,
+  resource:string,
   tracerConfig:TracerConfiguration,
   contextArgumentPosition:number,
 }) {
@@ -121,7 +125,7 @@ export function createTraceFunction({
     return (tracedFunction:Function) => {
       return async (...args:any[]) => {
         return traceFunction({
-          resource,
+          resource: resource || defaultResource,
           service: service || defaultService,
           tracerConfig,
           contextArgumentPosition,

--- a/src/traceFunc.ts
+++ b/src/traceFunc.ts
@@ -52,12 +52,12 @@ export function traceFunc({
 
 export function createTraceDecorator({
   service: defaultService,
-  resource: defaultResource,
+  name: defaultName,
   tracerConfig,
   contextArgumentPosition = 1,
 }:{
   service:string,
-  resource:string,
+  name:string,
   tracerConfig:TracerConfiguration,
   contextArgumentPosition:number,
 }) {
@@ -80,11 +80,11 @@ export function createTraceDecorator({
       const tracedFunction = descriptor.value;
       descriptor.value = function traceDecorator(...args:any[]) {
         return traceFunction.call(this, {
-          resource: resource || defaultResource,
+          resource,
           service: service || defaultService,
           tracerConfig,
           contextArgumentPosition,
-          name,
+          name: name || defaultName,
           annotator,
           tags,
           context,
@@ -98,12 +98,12 @@ export function createTraceDecorator({
 
 export function createTraceFunction({
   service: defaultService,
-  resource: defaultResource,
+  name: defaultName,
   tracerConfig,
   contextArgumentPosition = 1,
 }:{
   service:string,
-  resource:string,
+  name:string,
   tracerConfig:TracerConfiguration,
   contextArgumentPosition:number,
 }) {
@@ -125,11 +125,11 @@ export function createTraceFunction({
     return (tracedFunction:Function) => {
       return async (...args:any[]) => {
         return traceFunction({
-          resource: resource || defaultResource,
+          resource,
           service: service || defaultService,
           tracerConfig,
           contextArgumentPosition,
-          name,
+          name: name || defaultName,
           annotator,
           tags,
           context,


### PR DESCRIPTION
Its nice to set the default span name for a decorator since you often times want the same name for a bunch of functions that are similar (makes it easier to aggregate them in datadog).