### PR TITLE
Support for tags when reporting metrics

### DIFF
--- a/__tests__/Span.ts
+++ b/__tests__/Span.ts
@@ -92,7 +92,7 @@ describe(`Span`, () => {
       const emptyTags = {};
       span.tags = {};
       span.setTags(emptyTags);
-      expect(span.tags).toMatchObject(emptyTags);
+      expect(_.keys(span.tags)).toEqual([]);
     });
   });
 

--- a/__tests__/Span.ts
+++ b/__tests__/Span.ts
@@ -64,6 +64,38 @@ describe(`Span`, () => {
     });
   });
 
+  describe(`setTags`, () => {
+    let tags;
+    beforeEach(() => {
+      tags = { foo: 'bar' };
+      span.setTags(tags);
+    });
+
+    it(`adds the tags to the 'tags' property`, () => {
+      expect(span.tags).toMatchObject(tags);
+    });
+
+    it(`adds the tags to any existing tags`, () => {
+      const newTags = { bar: 'foo' };
+      span.setTags(newTags);
+      expect(span.tags).toMatchObject({ ...tags, ...newTags });
+    });
+
+    it(`removes tags with non-primitive values`, () => {
+      const nonPrimitive = { bar: { baz: 'qux' } };
+      span.setTags(nonPrimitive as any);
+      expect(span.tags).toMatchObject(tags);
+      expect(span.tags).not.toMatchObject(nonPrimitive);
+    });
+
+    it(`doesn't add anything if you pass it an empty object`, () => {
+      const emptyTags = {};
+      span.tags = {};
+      span.setTags(emptyTags);
+      expect(span.tags).toMatchObject(emptyTags);
+    });
+  });
+
   describe(`setMetrics`, () => {
     let metrics;
     beforeEach(() => {
@@ -98,6 +130,13 @@ describe(`Span`, () => {
       expect(span.meta).toMatchObject({
         'error.name': 'Error',
         'error.message': errorMessage,
+      });
+    });
+
+    it(`adds the error tags to the 'tags' property`, () => {
+      expect(span.tags).toMatchObject({
+        'error.name': 'Error',
+        error: '1',
       });
     });
   });

--- a/__tests__/Tracer.ts
+++ b/__tests__/Tracer.ts
@@ -164,10 +164,10 @@ describe(`Trace`, () => {
   describe(`recordSpanTiming`, () => {
     it(`allows you to pass it extra metadata`, () => {
       (tracer as any).reporter.reportTiming = jest.fn();
-      const extraMetadata = { baz: 'qux' };
-      (tracer as any).recordSpanTiming(span, extraMetadata);
+      const extraTags = { baz: 'qux' };
+      (tracer as any).recordSpanTiming(span, extraTags);
       expect((tracer as any).reporter.reportTiming.mock.calls[0][0].tags).toMatchObject(
-        extraMetadata,
+        extraTags,
       );
     });
 
@@ -181,19 +181,19 @@ describe(`Trace`, () => {
     });
   });
 
-  describe(`globalProperties`, () => {
+  describe(`globalTags`, () => {
     it(`works if you provide it with a function`, () => {
-      const globalProperties = { baz: 'quux' };
-      (tracer as any).config.globalProperties = () => globalProperties;
+      const globalTags = { baz: 'quux' };
+      (tracer as any).config.globalTags = () => globalTags;
       (tracer as any).recordSpanTiming(span);
-      expect((tracer as any).reporter.timings.buffer[0].tags).toMatchObject(globalProperties);
+      expect((tracer as any).reporter.timings.buffer[0].tags).toMatchObject(globalTags);
     });
 
     it(`works if you provide it with an object`, () => {
-      const globalProperties = { baz: 'quux' };
-      (tracer as any).config.globalProperties = globalProperties;
+      const globalTags = { baz: 'quux' };
+      (tracer as any).config.globalTags = globalTags;
       (tracer as any).recordSpanTiming(span);
-      expect((tracer as any).reporter.timings.buffer[0].tags).toMatchObject(globalProperties);
+      expect((tracer as any).reporter.timings.buffer[0].tags).toMatchObject(globalTags);
     });
   });
 });

--- a/src/Tracer.ts
+++ b/src/Tracer.ts
@@ -35,14 +35,10 @@ export default class Tracer {
 
     const span = new Span(resource, name, service);
 
-    const globalProperties = _.isFunction(this.config.globalProperties)
-      ? this.config.globalProperties()
-      : this.config.globalProperties;
+    const globalProperties = this.getGlobalProperties();
     span.setMeta(globalProperties);
 
-    const globalTags = _.isFunction(this.config.globalTags)
-      ? this.config.globalTags()
-      : this.config.globalTags;
+    const globalTags = this.getGlobalTags();
     span.setTags(globalTags);
 
     this.spanStack = [span];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,10 @@ export interface SpanMeta {
   [key: string]: string;
 }
 
+export interface SpanTags {
+  [key: string]: string;
+}
+
 export interface SpanMetrics {
   [key: string]: number;
 }
@@ -50,6 +54,7 @@ export interface TracerConfiguration extends ReporterParamsConfiguration {
   minimumDurationMs?: number;
   fullTraceSampleRate?: number;
   globalProperties?: { [key: string]: string } | Function;
+  globalTags?: { [key: string]: string } | Function;
   reporter?: null | AbstractReporter;
   traceId?: number;
 }


### PR DESCRIPTION
APM doesn't support tags (yet! their reps say they are working on it). In the meantime we can send tags via metrics, which tracer already supports sending both. This introduces the ability to set tags on spans that for now will only be reported via metrics. Tags are different than metadata as datadog considers tags to be part of their cardinality (and charges more) since you can actually filter by them.

This is all in support of the ability to tag traces/metrics for those traces in nacho with the scene they came from so we can alarm to specific teams.