### PR TITLE
Remove timings construct

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,3 +5,4 @@
 * BREAKING CHANGE: Tracer now requires a reporter
 * BREAKING CHANGE: TracerConfiguration.fullTraceSampleRate is now just sampleRate
 * BREAKING CHANGE: TracerConfiguration.flushHandler no longer has the timings first argument
+* BREAKING CHANGE: TracerConfiguration.globalMetadata is now named globalTags

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## 1.0.x
 
-* BREAKING CHANGE: Tracer now requires a reporter
-* BREAKING CHANGE: TracerConfiguration.fullTraceSampleRate is now just sampleRate
-* BREAKING CHANGE: TracerConfiguration.flushHandler no longer has the timings first argument
-* BREAKING CHANGE: TracerConfiguration.globalMetadata is now named globalTags
+Breaking Changes:
+* Tracer now requires a reporter
+* TracerConfiguration.fullTraceSampleRate is now just sampleRate
+* TracerConfiguration.flushHandler no longer has the timings first argument
+* TracerConfiguration.globalMetadata is now named globalTags

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,7 @@
+# Change log
+
+## 1.0.x
+
+* BREAKING CHANGE: Tracer now requires a reporter
+* BREAKING CHANGE: TracerConfiguration.fullTraceSampleRate is now just sampleRate
+* BREAKING CHANGE: TracerConfiguration.flushHandler no longer has the timings first argument

--- a/__tests__/Span.ts
+++ b/__tests__/Span.ts
@@ -96,24 +96,6 @@ describe(`Span`, () => {
     });
   });
 
-  describe(`setMetrics`, () => {
-    let metrics;
-    beforeEach(() => {
-      metrics = { foo: 1 };
-      span.setMetrics(metrics);
-    });
-
-    it(`adds the metrics to the 'metrics' property`, () => {
-      expect(span.metrics).toMatchObject(metrics);
-    });
-
-    it(`adds the metrics to any existing metrics`, () => {
-      const newMetrics = { bar: 2 };
-      span.setMetrics(newMetrics);
-      expect(span.metrics).toMatchObject({ ...metrics, ...newMetrics });
-    });
-  });
-
   describe(`setError`, () => {
     let error, errorMessage;
     beforeEach(() => {

--- a/__tests__/Tracer.ts
+++ b/__tests__/Tracer.ts
@@ -7,15 +7,18 @@ import { defaultConfig } from '../src/Tracer';
 import { TracerConfiguration } from '../src/interfaces';
 
 describe(`Trace`, () => {
-  let tracer: Tracer, config: TracerConfiguration, span: Span, resource, name, service;
+  let tracer: Tracer, config: TracerConfiguration, span: Span, resource, name, service, reporter: Reporter;
 
   beforeEach(() => {
+    reporter = new Reporter({
+      flushHandler: async (...args: any[]) => args,
+    });
     config = {
       minimumDurationMs: 0,
       globalMetadata: () => ({
         foo: 'bar',
       }),
-      flushHandler: async (...args: any[]) => args,
+      reporter,
     };
     resource = 'FooResource';
     name = 'FooName';
@@ -31,7 +34,7 @@ describe(`Trace`, () => {
     });
 
     it(`initializes a queue`, () => {
-      expect((tracer as any).reporter).toBeInstanceOf(Reporter);
+      expect((tracer as any).reporter).toEqual(reporter);
     });
   });
 

--- a/__tests__/traceFunc.ts
+++ b/__tests__/traceFunc.ts
@@ -79,7 +79,7 @@ describe(`createTraceDecorator`, () => {
     trace = createTraceDecorator({
       service: 'FooService',
       tracerConfig: {
-        fullTraceSampleRate: 1,
+        sampleRate: 1,
         reporter,
       },
       contextArgumentPosition: 1,
@@ -100,7 +100,7 @@ describe(`createTraceDecorator`, () => {
     jest.runTimersToTime((reporter as any).config.flushIntervalSeconds * 1000);
 
     expect(mock).toHaveBeenCalledTimes(1);
-    const traces = mock.mock.calls[0][1];
+    const traces = mock.mock.calls[0][0];
     expect(traces[0].service).toEqual('FooService');
     expect(typeof traces[0].traceId).toEqual('number');
     expect(typeof traces[0].duration).toEqual('number');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convoy/tracer",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "description": "A tracing library",
   "license": "Apache-2.0",
   "repository": "convoyinc/tracer",

--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -4,10 +4,9 @@ import * as uuid from 'uuid';
 import CircularBuffer from 'circularbuffer';
 
 import Span from './Span';
-import { AbstractReporter, Logger, ReporterConfiguration, TracerConfiguration, Timing } from './interfaces';
+import { AbstractReporter, Logger, ReporterConfiguration, TracerConfiguration } from './interfaces';
 
 export const defaultReporterConfig:ReporterConfiguration = {
-  maxTimingsBatchSize: 50,
   maxTracesBatchSize: 20,
   flushIntervalSeconds: 30,
   logger: console,
@@ -16,7 +15,6 @@ export const defaultReporterConfig:ReporterConfiguration = {
 
 export default class Reporter implements AbstractReporter {
   private traces = new CircularBuffer<Span>(100);
-  private timings = new CircularBuffer<Timing>(100);
   private isFlushing = false;
   private lastFlush: Date | null = null;
   private isPending = false;
@@ -25,15 +23,6 @@ export default class Reporter implements AbstractReporter {
   constructor(private config: ReporterConfiguration) {
     this.config = _.defaults(config, defaultReporterConfig);
     this.log = this.config.logger;
-  }
-
-  public reportTiming(timing: Timing) {
-    if (_.isEmpty(timing.id)) {
-      timing.id = uuid.v4();
-    }
-
-    this.timings.enq(timing);
-    this.requestFlush();
   }
 
   public reportTrace(trace: Span) {
@@ -67,8 +56,7 @@ export default class Reporter implements AbstractReporter {
     this.lastFlush = new Date();
   }
 
-  public removeFromQueue(timingsToRemove: Timing[], tracesToRemove: Span[]) {
-    this.timings.replace(..._.without(this.timings.toArray(), ...timingsToRemove));
+  public removeFromQueue(tracesToRemove: Span[]) {
     this.traces.replace(..._.without(this.traces.toArray(), ...tracesToRemove));
   }
 
@@ -81,9 +69,9 @@ export default class Reporter implements AbstractReporter {
 
     try {
       while (this.haveItemsToFlush) {
-        const { timings, traces } = this.sliceFromQueue;
-        await this.config.flushHandler(timings, traces);
-        this.removeFromQueue(timings, traces);
+        const { traces } = this.sliceFromQueue;
+        await this.config.flushHandler(traces);
+        this.removeFromQueue(traces);
       }
     } catch (error) {
       this.log.error(`Error encountered while flushing items:\n`, error);
@@ -94,20 +82,18 @@ export default class Reporter implements AbstractReporter {
 
   get sliceFromQueue() {
     return {
-      timings: _.take(this.timings.toArray(), this.config.maxTimingsBatchSize),
       traces: _.take(this.traces.toArray(), this.config.maxTracesBatchSize),
     };
   }
 
   get queueSizes() {
     return {
-      timings: this.timings.size,
       traces: this.traces.size,
     };
   }
 
   get haveItemsToFlush() {
-    return !!(this.traces.size || this.timings.size);
+    return !!(this.traces.size);
   }
 }
 

--- a/src/Span.ts
+++ b/src/Span.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import * as now from '@streammedev/perfnow';
 
-import { SpanMeta, SpanMetrics, SpanTags } from './interfaces';
+import { SpanMeta, SpanTags } from './interfaces';
 
 /**
  * Spans represent the amount of time spent during a single operation. Traces
@@ -13,7 +13,6 @@ export default class Span {
   public start: number;
   public duration: number;
   public meta: SpanMeta = {};
-  public metrics?: SpanMetrics;
   public children: Span[] = [];
   public tags: SpanTags = {};
   public error: number = 0;
@@ -39,11 +38,6 @@ export default class Span {
     if (_.isEmpty(tags)) return this;
     const cleanTags = _(tags).omitBy(_.isObject).mapValues(_.toString).value();
     this.tags = { ...this.tags, ...cleanTags };
-    return this;
-  }
-
-  public setMetrics(metrics: SpanMetrics) {
-    this.metrics = { ...this.metrics, ...metrics };
     return this;
   }
 
@@ -106,7 +100,6 @@ export default class Span {
     setTags: () => Span,
     newChild: () => Span,
     setError: (error?:Error) => Span,
-    setMetrics: () => Span,
     removeShortSpans: () => Span,
     setTraceId: () => Span,
     get hasEnded() {

--- a/src/Tracer.ts
+++ b/src/Tracer.ts
@@ -6,12 +6,11 @@ import Span from './Span';
 import { ReporterConfiguration, TracerConfiguration, AbstractReporter } from './interfaces';
 import { pseudoUuid } from './utils';
 
-export const defaultConfig: TracerConfiguration = {
+export const defaultConfig = {
   minimumDurationMs: 10,
   sampleRate: 1,
   globalMetadata: {},
   globalTags: {},
-  reporter: null,
 };
 
 export default class Tracer {
@@ -20,7 +19,6 @@ export default class Tracer {
 
   constructor(private config: TracerConfiguration) {
     this.config = _.defaults(config, defaultConfig);
-    this.reporter = this.config.reporter || new Reporter(this.config as any);
 
     autobind(this);
   }

--- a/src/Tracer.ts
+++ b/src/Tracer.ts
@@ -19,6 +19,7 @@ export default class Tracer {
 
   constructor(private config: TracerConfiguration) {
     this.config = _.defaults(config, defaultConfig);
+    this.reporter = this.config.reporter;
 
     autobind(this);
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,17 +2,9 @@ import Span from './Span';
 import Tracer from './Tracer';
 
 export interface QueueState {
-  timings: Timing[];
   traces: Span[];
   isFlushing: boolean;
   lastFlush: string | null;
-}
-
-export interface Timing {
-  id?: string;
-  name: string;
-  duration: number;
-  tags?: { [key: string]: string };
 }
 
 export type Span = typeof Span;
@@ -25,11 +17,7 @@ export interface SpanTags {
   [key: string]: string;
 }
 
-export interface SpanMetrics {
-  [key: string]: number;
-}
-
-export type FlushFunction = (timings: Timing[], traces: Span[]) => any;
+export type FlushFunction = (traces: Span[]) => any;
 
 export interface Logger {
   info(...args: any[]): void;
@@ -38,12 +26,10 @@ export interface Logger {
 }
 
 export interface AbstractReporter {
-  reportTiming(timing: Timing): any;
   reportTrace(trace: Span): any;
 }
 
 export interface ReporterParamsConfiguration {
-  maxTimingsBatchSize?: number;
   maxTracesBatchSize?: number;
   flushIntervalSeconds?: number;
   logger?: Logger;
@@ -52,8 +38,8 @@ export interface ReporterParamsConfiguration {
 
 export interface TracerConfiguration extends ReporterParamsConfiguration {
   minimumDurationMs?: number;
-  fullTraceSampleRate?: number;
-  globalProperties?: { [key: string]: string } | Function;
+  sampleRate?: number;
+  globalMetadata?: { [key: string]: string } | Function;
   globalTags?: { [key: string]: string } | Function;
   reporter?: null | AbstractReporter;
   traceId?: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,22 +29,18 @@ export interface AbstractReporter {
   reportTrace(trace: Span): any;
 }
 
-export interface ReporterParamsConfiguration {
-  maxTracesBatchSize?: number;
-  flushIntervalSeconds?: number;
-  logger?: Logger;
-  flushHandler?: FlushFunction;
-}
-
-export interface TracerConfiguration extends ReporterParamsConfiguration {
+export interface TracerConfiguration  {
   minimumDurationMs?: number;
   sampleRate?: number;
   globalMetadata?: { [key: string]: string } | Function;
   globalTags?: { [key: string]: string } | Function;
-  reporter?: null | AbstractReporter;
+  reporter: AbstractReporter;
   traceId?: number;
 }
 
-export interface ReporterConfiguration extends ReporterParamsConfiguration {
-  flushHandler: FlushFunction;
+export interface ReporterConfiguration {
+  maxTracesBatchSize?: number;
+  flushIntervalSeconds?: number;
+  logger?: Logger;
+  flushHandler?: FlushFunction;
 }

--- a/src/traceFunc.ts
+++ b/src/traceFunc.ts
@@ -57,7 +57,7 @@ export function createTraceDecorator({
   errorAnnotator,
 }:{
   service:string,
-  name:string,
+  name?:string,
   tracerConfig:TracerConfiguration,
   contextArgumentPosition:number,
   errorAnnotator?:ErrorAnnotatorFunction,


### PR DESCRIPTION
This removes the separate storage of timings from traces in the library. The primary motivation is that it simplifies the library and reduces its concerns. The consumer can always achieve the existing behavior by breaking up traces and timings and doing sampling of the full trace in the flushHandler. There were certain behaviors or concerns built in that weren't necessary or would become cumbersome to add hooks for (i.e. changing the naming of timings, allowing timings for more than 2 levels deep of spans).