### PR TITLE
Set trace id up front, propagate deeply at the end

### DIFF
--- a/src/Tracer.ts
+++ b/src/Tracer.ts
@@ -41,6 +41,9 @@ export default class Tracer {
     const globalTags = this.getGlobalTags();
     span.setTags(globalTags);
 
+    const traceId = this.config.traceId || pseudoUuid();
+    span.setTraceId(traceId);
+
     this.spanStack = [span];
     return _.head(this.spanStack);
   }
@@ -89,11 +92,10 @@ export default class Tracer {
     const currentTrace = this.get();
     if (!currentTrace) return;
 
-    const traceId = this.config.traceId || pseudoUuid();
     this.spanStack = [];
     currentTrace.end();
     currentTrace.removeShortSpans(this.config.minimumDurationMs);
-    currentTrace.setTraceId(traceId);
+    currentTrace.setTraceId(currentTrace.traceId);
     this.recordTrace(currentTrace);
 
     return currentTrace;


### PR DESCRIPTION
Turns out you need to set the trace id up front on the top level trace span so that we can send it over the wire while the trace is still open.